### PR TITLE
Edit Rules + Drag-to-Reorder with Priority Indication

### DIFF
--- a/BrowserPicker/SettingsView.swift
+++ b/BrowserPicker/SettingsView.swift
@@ -112,6 +112,7 @@ private struct GeneralSettingsTab: View {
 private struct RulesSettingsTab: View {
     @State private var rules: [DomainRule] = []
     @State private var showingAddSheet = false
+    @State private var editingRule: DomainRule?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -146,7 +147,12 @@ private struct RulesSettingsTab: View {
             } else {
                 List {
                     ForEach(rules) { rule in
-                        RuleRow(rule: rule, onToggle: { toggleRule(rule) }, onDelete: { deleteRule(rule) })
+                        RuleRow(
+                            rule: rule,
+                            onToggle: { toggleRule(rule) },
+                            onEdit: { editingRule = rule },
+                            onDelete: { deleteRule(rule) }
+                        )
                     }
                 }
             }
@@ -156,6 +162,14 @@ private struct RulesSettingsTab: View {
             RuleEditorSheet(editingRule: nil, onSave: { rule in
                 rules.append(rule)
                 RuleEngine.saveRules(rules)
+            })
+        }
+        .sheet(item: $editingRule) { rule in
+            RuleEditorSheet(editingRule: rule, onSave: { updated in
+                if let index = rules.firstIndex(where: { $0.id == updated.id }) {
+                    rules[index] = updated
+                    RuleEngine.saveRules(rules)
+                }
             })
         }
     }
@@ -176,6 +190,7 @@ private struct RulesSettingsTab: View {
 private struct RuleRow: View {
     let rule: DomainRule
     let onToggle: () -> Void
+    let onEdit: () -> Void
     let onDelete: () -> Void
 
     var body: some View {
@@ -211,13 +226,24 @@ private struct RuleRow: View {
                 .toggleStyle(.switch)
                 .controlSize(.small)
 
+            Button(action: onEdit) {
+                Image(systemName: "pencil")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .help("Edit rule")
+
             Button(action: onDelete) {
                 Image(systemName: "trash")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
             .buttonStyle(.plain)
+            .help("Delete rule")
         }
+        .contentShape(Rectangle())
+        .onTapGesture(count: 2, perform: onEdit)
     }
 }
 

--- a/BrowserPicker/SettingsView.swift
+++ b/BrowserPicker/SettingsView.swift
@@ -153,7 +153,7 @@ private struct RulesSettingsTab: View {
         }
         .onAppear { rules = RuleEngine.loadRules() }
         .sheet(isPresented: $showingAddSheet) {
-            AddRuleSheet(onSave: { rule in
+            RuleEditorSheet(editingRule: nil, onSave: { rule in
                 rules.append(rule)
                 RuleEngine.saveRules(rules)
             })
@@ -221,7 +221,8 @@ private struct RuleRow: View {
     }
 }
 
-private struct AddRuleSheet: View {
+private struct RuleEditorSheet: View {
+    let editingRule: DomainRule?
     let onSave: (DomainRule) -> Void
 
     @Environment(\.dismiss) private var dismiss
@@ -233,9 +234,11 @@ private struct AddRuleSheet: View {
     @State private var browsers: [Browser] = []
     @State private var profiles: [BrowserProfile] = []
 
+    private var isEditing: Bool { editingRule != nil }
+
     var body: some View {
         VStack(spacing: 16) {
-            Text("Add Rule")
+            Text(isEditing ? "Edit Rule" : "Add Rule")
                 .font(.headline)
 
             Form {
@@ -257,7 +260,9 @@ private struct AddRuleSheet: View {
                     } else {
                         profiles = []
                     }
-                    selectedProfileDir = ""
+                    if !profiles.contains(where: { $0.directoryName == selectedProfileDir }) {
+                        selectedProfileDir = ""
+                    }
                 }
                 if !profiles.isEmpty {
                     Picker("Profile", selection: $selectedProfileDir) {
@@ -276,13 +281,20 @@ private struct AddRuleSheet: View {
                 Spacer()
                 Button("Save") {
                     let cleanPattern = pattern.trimmingCharacters(in: .whitespacesAndNewlines)
-                    let rule = DomainRule(
+                    var rule = editingRule ?? DomainRule(
                         pattern: cleanPattern,
                         matchType: matchType,
                         browserBundleID: selectedBrowserID,
                         profileDirectory: selectedProfileDir.isEmpty ? nil : selectedProfileDir,
                         incognito: incognito
                     )
+                    if isEditing {
+                        rule.pattern = cleanPattern
+                        rule.matchType = matchType
+                        rule.browserBundleID = selectedBrowserID
+                        rule.profileDirectory = selectedProfileDir.isEmpty ? nil : selectedProfileDir
+                        rule.incognito = incognito
+                    }
                     onSave(rule)
                     dismiss()
                 }
@@ -294,6 +306,16 @@ private struct AddRuleSheet: View {
         .frame(width: 380)
         .onAppear {
             browsers = BrowserDetector.detectInstalledBrowsers()
+            if let rule = editingRule {
+                pattern = rule.pattern
+                matchType = rule.matchType
+                selectedBrowserID = rule.browserBundleID
+                selectedProfileDir = rule.profileDirectory ?? ""
+                incognito = rule.incognito
+                if let browser = browsers.first(where: { $0.bundleID == rule.browserBundleID }) {
+                    profiles = ProfileDetector.detectProfiles(for: browser)
+                }
+            }
         }
     }
 }

--- a/BrowserPicker/SettingsView.swift
+++ b/BrowserPicker/SettingsView.swift
@@ -145,15 +145,30 @@ private struct RulesSettingsTab: View {
                 }
                 Spacer()
             } else {
+                HStack(spacing: 6) {
+                    Image(systemName: "info.circle")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text("Rules are matched top to bottom. First match wins. Drag to reorder.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 6)
+                .background(Color.secondary.opacity(0.08))
+
                 List {
-                    ForEach(rules) { rule in
+                    ForEach(Array(rules.enumerated()), id: \.element.id) { index, rule in
                         RuleRow(
+                            priority: index + 1,
                             rule: rule,
                             onToggle: { toggleRule(rule) },
                             onEdit: { editingRule = rule },
                             onDelete: { deleteRule(rule) }
                         )
                     }
+                    .onMove(perform: moveRule)
                 }
             }
         }
@@ -185,9 +200,15 @@ private struct RulesSettingsTab: View {
         rules.removeAll { $0.id == rule.id }
         RuleEngine.saveRules(rules)
     }
+
+    private func moveRule(from source: IndexSet, to destination: Int) {
+        rules.move(fromOffsets: source, toOffset: destination)
+        RuleEngine.saveRules(rules)
+    }
 }
 
 private struct RuleRow: View {
+    let priority: Int
     let rule: DomainRule
     let onToggle: () -> Void
     let onEdit: () -> Void
@@ -195,6 +216,11 @@ private struct RuleRow: View {
 
     var body: some View {
         HStack {
+            Text("#\(priority)")
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(.tertiary)
+                .frame(minWidth: 22, alignment: .leading)
+
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 4) {
                     Text(rule.pattern)


### PR DESCRIPTION
## Summary

Closes #1

Adds the ability to edit existing rules in place, drag them to reorder, and makes priority visible.

### Changes

- **Edit rules in place** — `AddRuleSheet` refactored into `RuleEditorSheet` with an optional `editingRule` parameter. Pencil icon on each row opens the editor pre-populated with that rule's values; double-clicking the row also opens the editor. Saving an edit updates the rule in place (preserves id, createdAt, and list position).
- **Drag-to-reorder** — `ForEach` now supports `onMove`, persisting the new order via `RuleEngine.saveRules`. Since rule priority equals array order (first match wins), reordering directly controls precedence.
- **Priority numbering** — Each row shows its position as `#1`, `#2`, `#3`... so users can see exactly which rule will fire first.
- **Explanation banner** — A subtle strip above the rules list reads: "Rules are matched top to bottom. First match wins. Drag to reorder."

### Commits

1. Refactor `AddRuleSheet` into `RuleEditorSheet` supporting edit mode
2. Add edit affordance (pencil button + double-click) to rule rows
3. Add drag-to-reorder, priority numbering, and the explanation banner

## Test plan

- [ ] Open Settings → Rules
- [ ] With no rules: confirm empty state still renders
- [ ] Add a rule via the `+` button; confirm it appears with `#1` prefix and the banner is visible
- [ ] Add a second rule; confirm `#2` prefix
- [ ] Click the pencil icon on a row — confirm the sheet opens with all fields pre-populated and title says "Edit Rule"
- [ ] Change the pattern, save — confirm the rule updates in place and keeps its position
- [ ] Double-click a row — confirm it opens the editor too
- [ ] Drag rule 2 above rule 1 — confirm numbering updates and order persists after closing/reopening Settings
- [ ] Toggle and delete still work as before

Made with [Cursor](https://cursor.com)