### PR TITLE
Rule Tester + Regex Tester for Rewrites

### DIFF
--- a/BrowserPicker/Services/URLRewriter.swift
+++ b/BrowserPicker/Services/URLRewriter.swift
@@ -3,6 +3,12 @@
 
 import Foundation
 
+struct RewriteStep {
+    let rule: RewriteRule
+    let before: String
+    let after: String
+}
+
 struct URLRewriter {
     private static let rulesFile = "rewrite-rules.json"
 
@@ -31,5 +37,27 @@ struct URLRewriter {
         }
 
         return URL(string: urlString) ?? url
+    }
+
+    /// Same logic as `rewrite(_:)` but returns each step that actually changed the URL.
+    /// Used by the Rule Tester UI to show users which rewrite rules fired.
+    static func traceRewrite(_ urlString: String) -> (finalURL: String, steps: [RewriteStep]) {
+        let rules = loadRules().filter(\.enabled)
+        var current = urlString
+        var steps: [RewriteStep] = []
+
+        for rule in rules {
+            guard let regex = try? NSRegularExpression(pattern: rule.pattern, options: [.caseInsensitive]) else {
+                continue
+            }
+            let range = NSRange(current.startIndex..., in: current)
+            let result = regex.stringByReplacingMatches(in: current, range: range, withTemplate: rule.replacement)
+            if result != current {
+                steps.append(RewriteStep(rule: rule, before: current, after: result))
+                current = result
+            }
+        }
+
+        return (current, steps)
     }
 }

--- a/BrowserPicker/SettingsView.swift
+++ b/BrowserPicker/SettingsView.swift
@@ -171,6 +171,10 @@ private struct RulesSettingsTab: View {
                     .onMove(perform: moveRule)
                 }
             }
+
+            Divider()
+
+            RuleTesterSection(rules: rules)
         }
         .onAppear { rules = RuleEngine.loadRules() }
         .sheet(isPresented: $showingAddSheet) {
@@ -204,6 +208,121 @@ private struct RulesSettingsTab: View {
     private func moveRule(from source: IndexSet, to destination: Int) {
         rules.move(fromOffsets: source, toOffset: destination)
         RuleEngine.saveRules(rules)
+    }
+}
+
+private struct RuleTesterSection: View {
+    let rules: [DomainRule]
+    @State private var input: String = ""
+    @State private var isExpanded: Bool = false
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $isExpanded) {
+            VStack(alignment: .leading, spacing: 8) {
+                TextField("https://example.com/path", text: $input)
+                    .textFieldStyle(.roundedBorder)
+
+                if !input.isEmpty {
+                    resultView
+                }
+            }
+            .padding(.top, 6)
+        } label: {
+            Label("Test a URL", systemImage: "wand.and.stars")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+    }
+
+    @ViewBuilder
+    private var resultView: some View {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let url = URL(string: trimmed), url.scheme != nil {
+            let trace = URLRewriter.traceRewrite(trimmed)
+            let finalURL = URL(string: trace.finalURL) ?? url
+            let match = RuleEngine.match(url: finalURL)
+
+            VStack(alignment: .leading, spacing: 6) {
+                if !trace.steps.isEmpty {
+                    rewriteChainView(steps: trace.steps)
+                }
+
+                matchView(finalURL: finalURL, match: match)
+            }
+        } else {
+            Text("Enter a valid URL (including http:// or https://)")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+        }
+    }
+
+    @ViewBuilder
+    private func rewriteChainView(steps: [RewriteStep]) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Rewrites applied")
+                .font(.caption2.bold())
+                .foregroundStyle(.secondary)
+            ForEach(Array(steps.enumerated()), id: \.offset) { _, step in
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("/\(step.rule.pattern)/")
+                        .font(.system(.caption2, design: .monospaced))
+                        .foregroundStyle(.tertiary)
+                    Text(step.after)
+                        .font(.system(.caption, design: .monospaced))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func matchView(finalURL: URL, match: RuleMatch?) -> some View {
+        if let match = match {
+            let priority = (rules.firstIndex(where: { $0.id == match.rule.id }) ?? -1) + 1
+            let browserName = browserDisplayName(for: match.browserBundleID)
+            let profileName = profileDisplayName(bundleID: match.browserBundleID, directory: match.profileDirectory)
+
+            HStack(spacing: 6) {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                    .font(.caption)
+                Text("Matches rule #\(priority)")
+                    .font(.caption.bold())
+                Text("→ \(browserName)\(profileName.map { " / \($0)" } ?? "")\(match.incognito ? " (incognito)" : "")")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+        } else {
+            HStack(spacing: 6) {
+                Image(systemName: "questionmark.circle")
+                    .foregroundStyle(.orange)
+                    .font(.caption)
+                Text("No rule matches — popup would be shown")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func browserDisplayName(for bundleID: String) -> String {
+        if let browser = BrowserDetector.detectInstalledBrowsers().first(where: { $0.bundleID == bundleID }) {
+            return browser.name
+        }
+        return bundleID.components(separatedBy: ".").last ?? bundleID
+    }
+
+    private func profileDisplayName(bundleID: String, directory: String?) -> String? {
+        guard let directory = directory else { return nil }
+        guard let browser = BrowserDetector.detectInstalledBrowsers().first(where: { $0.bundleID == bundleID }) else {
+            return directory
+        }
+        let profiles = ProfileDetector.detectProfiles(for: browser)
+        return profiles.first(where: { $0.directoryName == directory })?.name ?? directory
     }
 }
 

--- a/BrowserPicker/SettingsView.swift
+++ b/BrowserPicker/SettingsView.swift
@@ -592,6 +592,26 @@ private struct AddRewriteRuleSheet: View {
     @Environment(\.dismiss) private var dismiss
     @State private var pattern = ""
     @State private var replacement = ""
+    @State private var sampleURL = ""
+
+    private var regexError: String? {
+        guard !pattern.isEmpty else { return nil }
+        do {
+            _ = try NSRegularExpression(pattern: pattern, options: [.caseInsensitive])
+            return nil
+        } catch {
+            return error.localizedDescription
+        }
+    }
+
+    private var previewOutput: String? {
+        guard !sampleURL.isEmpty, !pattern.isEmpty, regexError == nil else { return nil }
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+            return nil
+        }
+        let range = NSRange(sampleURL.startIndex..., in: sampleURL)
+        return regex.stringByReplacingMatches(in: sampleURL, range: range, withTemplate: replacement)
+    }
 
     var body: some View {
         VStack(spacing: 16) {
@@ -603,9 +623,49 @@ private struct AddRewriteRuleSheet: View {
                 TextField("Replacement", text: $replacement, prompt: Text("e.g. $1"))
             }
 
+            if let error = regexError {
+                HStack(spacing: 4) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                        .font(.caption)
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                        .lineLimit(2)
+                }
+            }
+
             Text("Uses regex with capture groups. $1, $2, etc. reference matched groups.")
                 .font(.caption)
                 .foregroundStyle(.tertiary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Try it on a URL")
+                    .font(.caption2.bold())
+                    .foregroundStyle(.secondary)
+                TextField("https://example.com/?utm_source=x", text: $sampleURL)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(.caption, design: .monospaced))
+
+                if let output = previewOutput {
+                    HStack(spacing: 4) {
+                        Image(systemName: "arrow.right")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                        Text(output)
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(output == sampleURL ? .tertiary : .primary)
+                            .lineLimit(2)
+                            .truncationMode(.middle)
+                    }
+                    if output == sampleURL && !sampleURL.isEmpty {
+                        Text("Pattern did not match this URL")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+            }
 
             HStack {
                 Button("Cancel") { dismiss() }
@@ -617,11 +677,11 @@ private struct AddRewriteRuleSheet: View {
                     dismiss()
                 }
                 .keyboardShortcut(.defaultAction)
-                .disabled(pattern.isEmpty)
+                .disabled(pattern.isEmpty || regexError != nil)
             }
         }
         .padding(20)
-        .frame(width: 380)
+        .frame(width: 420)
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #2

Stacked on top of #8. Adds two read-only testers that make the rules and rewrites system understandable before you commit changes.

### Changes

- **Rule Tester** — A collapsible "Test a URL" section at the bottom of the Rules tab. Paste a URL and see:
  - Which rewrite rules fired (pattern + transformed URL per step)
  - Which domain rule matched, highlighted by its priority number
  - The resulting browser + profile + incognito flag (or "no rule matches — popup would be shown")
  - Pure simulation: no browser launches, no history is logged
- **Regex Tester for Rewrites** — Live preview inside the Add Rewrite Rule sheet:
  - Inline error if the regex pattern is invalid (Save is disabled while invalid; previously invalid regex was silently skipped at runtime)
  - "Try it on a URL" field with live transformed output as the user types
  - Hint when the pattern compiles but does not match the sample URL
- **`URLRewriter.traceRewrite`** — New helper that returns each rewrite step that changed the URL. Used by the Rule Tester. Production rewrite path is unchanged.

### Commits

1. Add `traceRewrite` helper to URLRewriter
2. Add Rule Tester section to the Rules tab
3. Add live regex preview + inline error to the rewrite rule sheet

## Test plan

- [ ] Open Settings → Rules → expand "Test a URL"
- [ ] Paste a URL that matches an existing rule — confirm the matched rule's priority number shows and the browser/profile is correct
- [ ] Paste a URL that doesn't match anything — confirm "No rule matches — popup would be shown"
- [ ] Add a rewrite rule that strips `?utm_*` params; paste a URL with utm in the tester — confirm the rewrite chain shows the change
- [ ] Open Settings → Rewrite → click `+` to add a rule
- [ ] Type an invalid regex like `(unclosed` — confirm the inline error appears and Save is disabled
- [ ] Type a valid regex; type a sample URL — confirm the live preview updates as you type
- [ ] Type a sample URL that the pattern doesn't match — confirm the "Pattern did not match" hint

Made with [Cursor](https://cursor.com)