### PR TITLE
App-Aware Routing

### DIFF
--- a/BrowserPicker/AppDelegate.swift
+++ b/BrowserPicker/AppDelegate.swift
@@ -76,11 +76,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func application(_ application: NSApplication, open urls: [URL]) {
         guard let rawURL = urls.first else { return }
-        print("[BrowserPicker] Received URL: \(rawURL.absoluteString)")
+        // Capture the source app synchronously, before any other work — the
+        // frontmost app at this moment is almost always the app the user
+        // clicked the link in.
+        let sourceApp = NSWorkspace.shared.frontmostApplication
+        let sourceAppBundleID = sourceApp?.bundleIdentifier
+        print("[BrowserPicker] Received URL: \(rawURL.absoluteString) from: \(sourceAppBundleID ?? "unknown")")
 
         let url = URLRewriter.rewrite(rawURL)
 
-        if let match = RuleEngine.match(url: url) {
+        if let match = RuleEngine.match(url: url, sourceAppBundleID: sourceAppBundleID) {
             let browsers = BrowserDetector.detectInstalledBrowsers()
             if let browser = browsers.first(where: { $0.bundleID == match.browserBundleID }) {
                 let profile: BrowserProfile?

--- a/BrowserPicker/Models/DomainRule.swift
+++ b/BrowserPicker/Models/DomainRule.swift
@@ -18,6 +18,10 @@ struct DomainRule: Codable, Identifiable {
     var incognito: Bool
     var enabled: Bool
     var createdAt: Date
+    /// Optional. When set, the rule only fires if the link came from this app
+    /// (matched against the frontmost app's bundle identifier at URL open time).
+    /// Defaults to nil for backward compatibility with existing rules.json files.
+    var sourceAppBundleID: String?
 
     init(
         pattern: String,
@@ -25,7 +29,8 @@ struct DomainRule: Codable, Identifiable {
         browserBundleID: String,
         profileDirectory: String? = nil,
         incognito: Bool = false,
-        enabled: Bool = true
+        enabled: Bool = true,
+        sourceAppBundleID: String? = nil
     ) {
         self.id = UUID()
         self.pattern = pattern
@@ -35,5 +40,6 @@ struct DomainRule: Codable, Identifiable {
         self.incognito = incognito
         self.enabled = enabled
         self.createdAt = Date()
+        self.sourceAppBundleID = sourceAppBundleID
     }
 }

--- a/BrowserPicker/Services/RuleEngine.swift
+++ b/BrowserPicker/Services/RuleEngine.swift
@@ -21,27 +21,38 @@ struct RuleEngine {
         PersistenceService.save(rules, to: rulesFile)
     }
 
-    static func match(url: URL) -> RuleMatch? {
+    static func match(url: URL, sourceAppBundleID: String? = nil) -> RuleMatch? {
         let rules = loadRules().filter(\.enabled)
         let urlString = url.absoluteString
         let host = url.host?.lowercased() ?? ""
 
-        print("[BrowserPicker] Rule engine: checking \(rules.count) rule(s) against: \(urlString)")
+        print("[BrowserPicker] Rule engine: checking \(rules.count) rule(s) against: \(urlString) (source: \(sourceAppBundleID ?? "unknown"))")
 
         for rule in rules {
-            switch rule.matchType {
-            case .domain:
-                if matchesDomain(host: host, pattern: rule.pattern.lowercased()) {
-                    return RuleMatch(rule: rule, browserBundleID: rule.browserBundleID, profileDirectory: rule.profileDirectory, incognito: rule.incognito)
+            // Source app filter: if the rule specifies a source app, it must match.
+            if let required = rule.sourceAppBundleID, !required.isEmpty {
+                guard let actual = sourceAppBundleID, actual == required else { continue }
+            }
+
+            // URL pattern check. An empty pattern combined with a source app filter
+            // means "match any URL from this app".
+            let trimmedPattern = rule.pattern.trimmingCharacters(in: .whitespaces)
+            let urlMatches: Bool
+            if trimmedPattern.isEmpty {
+                urlMatches = (rule.sourceAppBundleID?.isEmpty == false)
+            } else {
+                switch rule.matchType {
+                case .domain:
+                    urlMatches = matchesDomain(host: host, pattern: trimmedPattern.lowercased())
+                case .glob:
+                    urlMatches = matchesGlob(urlString: urlString, pattern: trimmedPattern)
+                case .regex:
+                    urlMatches = matchesRegex(urlString: urlString, pattern: trimmedPattern)
                 }
-            case .glob:
-                if matchesGlob(urlString: urlString, pattern: rule.pattern) {
-                    return RuleMatch(rule: rule, browserBundleID: rule.browserBundleID, profileDirectory: rule.profileDirectory, incognito: rule.incognito)
-                }
-            case .regex:
-                if matchesRegex(urlString: urlString, pattern: rule.pattern) {
-                    return RuleMatch(rule: rule, browserBundleID: rule.browserBundleID, profileDirectory: rule.profileDirectory, incognito: rule.incognito)
-                }
+            }
+
+            if urlMatches {
+                return RuleMatch(rule: rule, browserBundleID: rule.browserBundleID, profileDirectory: rule.profileDirectory, incognito: rule.incognito)
             }
         }
 

--- a/BrowserPicker/SettingsView.swift
+++ b/BrowserPicker/SettingsView.swift
@@ -214,6 +214,8 @@ private struct RulesSettingsTab: View {
 private struct RuleTesterSection: View {
     let rules: [DomainRule]
     @State private var input: String = ""
+    @State private var simulatedSourceAppID: String = ""
+    @State private var sourceApps: [RunningAppOption] = []
     @State private var isExpanded: Bool = false
 
     var body: some View {
@@ -221,6 +223,15 @@ private struct RuleTesterSection: View {
             VStack(alignment: .leading, spacing: 8) {
                 TextField("https://example.com/path", text: $input)
                     .textFieldStyle(.roundedBorder)
+
+                Picker("Simulate source app", selection: $simulatedSourceAppID) {
+                    Text("None").tag("")
+                    ForEach(sourceApps) { app in
+                        Text(app.name).tag(app.bundleID)
+                    }
+                }
+                .pickerStyle(.menu)
+                .controlSize(.small)
 
                 if !input.isEmpty {
                     resultView
@@ -234,6 +245,7 @@ private struct RuleTesterSection: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 8)
+        .onAppear { sourceApps = detectRunningSourceApps() }
     }
 
     @ViewBuilder
@@ -242,7 +254,8 @@ private struct RuleTesterSection: View {
         if let url = URL(string: trimmed), url.scheme != nil {
             let trace = URLRewriter.traceRewrite(trimmed)
             let finalURL = URL(string: trace.finalURL) ?? url
-            let match = RuleEngine.match(url: finalURL)
+            let sourceApp: String? = simulatedSourceAppID.isEmpty ? nil : simulatedSourceAppID
+            let match = RuleEngine.match(url: finalURL, sourceAppBundleID: sourceApp)
 
             VStack(alignment: .leading, spacing: 6) {
                 if !trace.steps.isEmpty {

--- a/BrowserPicker/SettingsView.swift
+++ b/BrowserPicker/SettingsView.swift
@@ -342,13 +342,30 @@ private struct RuleRow: View {
 
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 4) {
-                    Text(rule.pattern)
-                        .font(.system(.callout, design: .monospaced, weight: .medium))
-                    Text("(\(rule.matchType.rawValue))")
-                        .font(.caption2)
-                        .foregroundStyle(.tertiary)
+                    if rule.pattern.isEmpty {
+                        Text("(any URL)")
+                            .font(.system(.callout, design: .monospaced, weight: .medium))
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Text(rule.pattern)
+                            .font(.system(.callout, design: .monospaced, weight: .medium))
+                        Text("(\(rule.matchType.rawValue))")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
                 }
                 HStack(spacing: 4) {
+                    if let appID = rule.sourceAppBundleID, !appID.isEmpty {
+                        Image(systemName: "app.dashed")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                        Text("from \(appID.components(separatedBy: ".").last ?? appID)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text("·")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
                     Text(rule.browserBundleID.components(separatedBy: ".").last ?? rule.browserBundleID)
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -392,6 +409,24 @@ private struct RuleRow: View {
     }
 }
 
+private struct RunningAppOption: Identifiable, Hashable {
+    let id: String
+    let name: String
+    var bundleID: String { id }
+}
+
+private func detectRunningSourceApps() -> [RunningAppOption] {
+    var seen = Set<String>()
+    let apps: [RunningAppOption] = NSWorkspace.shared.runningApplications.compactMap { app in
+        guard let bundleID = app.bundleIdentifier, app.activationPolicy != .prohibited else { return nil }
+        if seen.contains(bundleID) { return nil }
+        seen.insert(bundleID)
+        let name = app.localizedName ?? bundleID
+        return RunningAppOption(id: bundleID, name: name)
+    }
+    return apps.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+}
+
 private struct RuleEditorSheet: View {
     let editingRule: DomainRule?
     let onSave: (DomainRule) -> Void
@@ -402,10 +437,18 @@ private struct RuleEditorSheet: View {
     @State private var selectedBrowserID = ""
     @State private var selectedProfileDir = ""
     @State private var incognito = false
+    @State private var selectedSourceAppID = ""
     @State private var browsers: [Browser] = []
     @State private var profiles: [BrowserProfile] = []
+    @State private var sourceApps: [RunningAppOption] = []
 
     private var isEditing: Bool { editingRule != nil }
+    private var hasSourceApp: Bool { !selectedSourceAppID.isEmpty }
+    private var canSave: Bool {
+        guard !selectedBrowserID.isEmpty else { return false }
+        // Must have at least a pattern or a source app filter.
+        return !pattern.trimmingCharacters(in: .whitespaces).isEmpty || hasSourceApp
+    }
 
     var body: some View {
         VStack(spacing: 16) {
@@ -413,10 +456,22 @@ private struct RuleEditorSheet: View {
                 .font(.headline)
 
             Form {
-                TextField("Pattern", text: $pattern, prompt: Text("e.g. github.com"))
+                TextField("Pattern", text: $pattern, prompt: Text(hasSourceApp ? "Optional when source app is set" : "e.g. github.com"))
                 Picker("Match type", selection: $matchType) {
                     ForEach(RuleMatchType.allCases, id: \.self) { type in
                         Text(type.rawValue).tag(type)
+                    }
+                }
+                Picker("Source app", selection: $selectedSourceAppID) {
+                    Text("Any").tag("")
+                    if let editing = editingRule,
+                       let bundleID = editing.sourceAppBundleID,
+                       !bundleID.isEmpty,
+                       !sourceApps.contains(where: { $0.bundleID == bundleID }) {
+                        Text("\(bundleID) (not running)").tag(bundleID)
+                    }
+                    ForEach(sourceApps) { app in
+                        Text(app.name).tag(app.bundleID)
                     }
                 }
                 Picker("Browser", selection: $selectedBrowserID) {
@@ -446,18 +501,27 @@ private struct RuleEditorSheet: View {
                 Toggle("Incognito / Private", isOn: $incognito)
             }
 
+            if hasSourceApp {
+                Text("Only links coming from this app will match this rule.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
             HStack {
                 Button("Cancel") { dismiss() }
                     .keyboardShortcut(.cancelAction)
                 Spacer()
                 Button("Save") {
                     let cleanPattern = pattern.trimmingCharacters(in: .whitespacesAndNewlines)
+                    let sourceApp = selectedSourceAppID.isEmpty ? nil : selectedSourceAppID
                     var rule = editingRule ?? DomainRule(
                         pattern: cleanPattern,
                         matchType: matchType,
                         browserBundleID: selectedBrowserID,
                         profileDirectory: selectedProfileDir.isEmpty ? nil : selectedProfileDir,
-                        incognito: incognito
+                        incognito: incognito,
+                        sourceAppBundleID: sourceApp
                     )
                     if isEditing {
                         rule.pattern = cleanPattern
@@ -465,24 +529,27 @@ private struct RuleEditorSheet: View {
                         rule.browserBundleID = selectedBrowserID
                         rule.profileDirectory = selectedProfileDir.isEmpty ? nil : selectedProfileDir
                         rule.incognito = incognito
+                        rule.sourceAppBundleID = sourceApp
                     }
                     onSave(rule)
                     dismiss()
                 }
                 .keyboardShortcut(.defaultAction)
-                .disabled(pattern.isEmpty || selectedBrowserID.isEmpty)
+                .disabled(!canSave)
             }
         }
         .padding(20)
-        .frame(width: 380)
+        .frame(width: 420)
         .onAppear {
             browsers = BrowserDetector.detectInstalledBrowsers()
+            sourceApps = detectRunningSourceApps()
             if let rule = editingRule {
                 pattern = rule.pattern
                 matchType = rule.matchType
                 selectedBrowserID = rule.browserBundleID
                 selectedProfileDir = rule.profileDirectory ?? ""
                 incognito = rule.incognito
+                selectedSourceAppID = rule.sourceAppBundleID ?? ""
                 if let browser = browsers.first(where: { $0.bundleID == rule.browserBundleID }) {
                     profiles = ProfileDetector.detectProfiles(for: browser)
                 }


### PR DESCRIPTION
## Summary

Closes #4

Stacked on top of #9. Adds the ability to route links based on which app sent them — the most-requested feature for clean work/personal separation.

### Changes

- **Source app detection** — `AppDelegate` captures `NSWorkspace.shared.frontmostApplication` synchronously the moment a URL arrives. The frontmost app at that point is almost always the source.
- **`DomainRule.sourceAppBundleID`** — Optional field added to the model. `Codable` synthesis uses `decodeIfPresent`, so existing `rules.json` files keep working without migration.
- **`RuleEngine.match`** — Now accepts an optional `sourceAppBundleID`. Rules with a source app filter only fire when the source matches. Rules without a source app filter behave as before.
- **App-only rules** — A rule with an empty pattern + a source app filter matches *any* URL from that app (e.g., "all links from Slack → Chrome Work").
- **Source App picker** in the Rule editor — Populated from currently running apps (deduped, sorted). When editing a rule whose source app isn't running, that bundle ID is shown as "(not running)" so the rule remains editable.
- **Row display** — `RuleRow` shows a "from <app>" badge when a source app filter is set, and shows "(any URL)" when the pattern is empty.
- **Rule Tester source app sim** — The tester now has a "Simulate source app" picker so you can verify app-aware rules without clicking a real link.

### No magic precedence

App-aware rules live in the same Rules list as everything else and are matched by position (first match wins). Combined with drag-to-reorder from #1, the user has full control over precedence.

### Commits

1. Add source app filter to rule engine (model + matching + AppDelegate detection)
2. Add Source App picker to rule editor and row display
3. Add source app simulator to Rule Tester

## Test plan

- [ ] Existing rules.json with no source app field loads and behaves identically (verify by checking existing rules still fire)
- [ ] Add a rule: pattern empty, source app = Slack, browser = Chrome Work — confirm Save is enabled
- [ ] Click a link in Slack — confirm Chrome Work opens (no popup)
- [ ] Click a link in Mail — confirm popup shows (Slack rule didn't match)
- [ ] Add a rule: pattern = "github.com", source app = Slack — confirm only Slack-originated github.com links use the rule; clicking from Notes shows the popup
- [ ] Edit an app-aware rule — confirm Source app picker is pre-filled
- [ ] Open Rule Tester, paste a URL, change "Simulate source app" — confirm matched rule changes appropriately
- [ ] Restart the app — confirm app-aware rules persist

Made with [Cursor](https://cursor.com)