### PR TITLE
Remember My Choice

### DIFF
--- a/BrowserPicker/AppDelegate.swift
+++ b/BrowserPicker/AppDelegate.swift
@@ -101,10 +101,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
-        showPopup(for: url)
+        showPopup(for: url, sourceApp: sourceApp)
     }
 
-    private func showPopup(for url: URL) {
+    private func showPopup(for url: URL, sourceApp: NSRunningApplication?) {
         pendingURL = url
         let browsers = BrowserDetector.detectInstalledBrowsers()
 
@@ -113,7 +113,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             profiles[browser.bundleID] = ProfileDetector.detectProfiles(for: browser)
         }
 
-        panelController.show(url: url, browsers: browsers, profiles: profiles)
+        panelController.show(url: url, browsers: browsers, profiles: profiles, sourceApp: sourceApp)
     }
 
     @objc private func handleOpenSettings() {

--- a/BrowserPicker/Panel/FloatingPanelController.swift
+++ b/BrowserPicker/Panel/FloatingPanelController.swift
@@ -11,7 +11,7 @@ final class FloatingPanelController {
 
     var onProfileSelected: ((Browser, BrowserProfile?, Bool) -> Void)?
 
-    func show(url: URL, browsers: [Browser], profiles: [String: [BrowserProfile]]) {
+    func show(url: URL, browsers: [Browser], profiles: [String: [BrowserProfile]], sourceApp: NSRunningApplication?) {
         dismiss()
 
         let keyboardState = PopupKeyboardState()
@@ -19,6 +19,8 @@ final class FloatingPanelController {
             url: url,
             browsers: browsers,
             profiles: profiles,
+            sourceAppBundleID: sourceApp?.bundleIdentifier,
+            sourceAppName: sourceApp?.localizedName,
             keyboardState: keyboardState,
             onProfileSelected: { [weak self] browser, profile, incognito in
                 self?.onProfileSelected?(browser, profile, incognito)

--- a/BrowserPicker/Views/RouterPopup/RouterPopupView.swift
+++ b/BrowserPicker/Views/RouterPopup/RouterPopupView.swift
@@ -3,6 +3,12 @@
 
 import SwiftUI
 
+enum RememberTarget: String, CaseIterable, Identifiable {
+    case domain
+    case sourceApp
+    var id: String { rawValue }
+}
+
 struct RouterPopupView: View {
     let url: URL
     let browsers: [Browser]
@@ -17,6 +23,25 @@ struct RouterPopupView: View {
     @State private var highlightedProfileIndex: Int = -1
     @State private var isInProfilePanel: Bool = false
     @State private var incognitoMode: Bool = false
+    @State private var rememberMode: Bool = false
+    @State private var rememberTarget: RememberTarget = .domain
+    @State private var includeSubdomains: Bool = false
+
+    private var domainForURL: String? {
+        url.host?.lowercased()
+    }
+
+    private var rootDomainForURL: String? {
+        guard let host = url.host else { return nil }
+        let parts = host.split(separator: ".")
+        guard parts.count >= 2 else { return host }
+        return parts.suffix(2).joined(separator: ".")
+    }
+
+    private var canRememberForApp: Bool {
+        guard let id = sourceAppBundleID, !id.isEmpty else { return false }
+        return id != Bundle.main.bundleIdentifier
+    }
 
     private var selectedBrowser: Browser? {
         browsers.first { $0.id == selectedBrowserID }
@@ -52,13 +77,60 @@ struct RouterPopupView: View {
         }
     }
 
+    private func launch(browser: Browser, profile: BrowserProfile?) {
+        if rememberMode {
+            saveRememberRule(browser: browser, profile: profile)
+        }
+        onProfileSelected(browser, profile, incognitoMode)
+    }
+
+    private func saveRememberRule(browser: Browser, profile: BrowserProfile?) {
+        var rules = RuleEngine.loadRules()
+
+        let pattern: String
+        let matchType: RuleMatchType
+        let sourceApp: String?
+
+        switch rememberTarget {
+        case .domain:
+            guard let host = domainForURL else { return }
+            pattern = includeSubdomains ? (rootDomainForURL ?? host) : host
+            matchType = .domain
+            sourceApp = nil
+        case .sourceApp:
+            guard canRememberForApp, let appID = sourceAppBundleID else { return }
+            pattern = ""
+            matchType = .domain
+            sourceApp = appID
+        }
+
+        // Conflict: replace any existing rule with the same target
+        // (same source app + same pattern) so users don't end up with duplicates.
+        rules.removeAll { existing in
+            (existing.sourceAppBundleID ?? "") == (sourceApp ?? "") &&
+            existing.pattern.lowercased() == pattern.lowercased()
+        }
+
+        let newRule = DomainRule(
+            pattern: pattern,
+            matchType: matchType,
+            browserBundleID: browser.bundleID,
+            profileDirectory: profile?.directoryName,
+            incognito: incognitoMode,
+            sourceAppBundleID: sourceApp
+        )
+        rules.append(newRule)
+        RuleEngine.saveRules(rules)
+        print("[BrowserPicker] Remembered choice as rule: \(pattern.isEmpty ? "(any URL)" : pattern) → \(browser.name)")
+    }
+
     private func handleKeyAction(_ action: PopupKeyAction) {
         switch action {
         case .selectBrowser(let index):
             if index < browsers.count {
                 highlightedIndex = index
                 isInProfilePanel = false
-                onProfileSelected(browsers[index], nil, incognitoMode)
+                launch(browser: browsers[index], profile: nil)
             }
         case .moveUp:
             if isInProfilePanel {
@@ -94,10 +166,10 @@ struct RouterPopupView: View {
         case .confirm:
             if isInProfilePanel && highlightedProfileIndex >= 0 && highlightedProfileIndex < selectedProfiles.count {
                 if let browser = selectedBrowser {
-                    onProfileSelected(browser, selectedProfiles[highlightedProfileIndex], incognitoMode)
+                    launch(browser: browser, profile: selectedProfiles[highlightedProfileIndex])
                 }
             } else {
-                onProfileSelected(browsers[highlightedIndex], nil, incognitoMode)
+                launch(browser: browsers[highlightedIndex], profile: nil)
             }
         case .copyURL:
             NSPasteboard.general.clearContents()
@@ -111,6 +183,11 @@ struct RouterPopupView: View {
     private var browserList: some View {
         VStack(spacing: 0) {
             urlHeader
+
+            if rememberMode {
+                Divider()
+                rememberStrip
+            }
 
             Divider()
 
@@ -131,7 +208,7 @@ struct RouterPopupView: View {
                             },
                             onBrowserClicked: {
                                 print("[BrowserPicker] Browser clicked: \(browser.name) — using default profile")
-                                onProfileSelected(browser, nil, incognitoMode)
+                                launch(browser: browser, profile: nil)
                             }
                         )
                     }
@@ -171,7 +248,7 @@ struct RouterPopupView: View {
                         ) {
                             if let browser = selectedBrowser {
                                 print("[BrowserPicker] Profile selected: \(browser.name) → \(profile.name)")
-                                onProfileSelected(browser, profile, incognitoMode)
+                                launch(browser: browser, profile: profile)
                             }
                         }
                     }
@@ -208,6 +285,19 @@ struct RouterPopupView: View {
             .help("Incognito mode (i)")
 
             Button(action: {
+                rememberMode.toggle()
+                if rememberMode && !canRememberForApp {
+                    rememberTarget = .domain
+                }
+            }) {
+                Image(systemName: rememberMode ? "bookmark.fill" : "bookmark")
+                    .font(.caption)
+                    .foregroundStyle(rememberMode ? .primary : .tertiary)
+            }
+            .buttonStyle(.plain)
+            .help("Remember next choice as a rule")
+
+            Button(action: {
                 NSPasteboard.general.clearContents()
                 NSPasteboard.general.setString(url.absoluteString, forType: .string)
                 NotificationCenter.default.post(name: .dismissPopup, object: nil)
@@ -231,6 +321,47 @@ struct RouterPopupView: View {
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
+    }
+}
+
+    private var rememberStrip: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                Image(systemName: "bookmark.fill")
+                    .font(.caption2)
+                    .foregroundStyle(.tint)
+                Text("Save next choice as a rule for")
+                    .font(.caption.bold())
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+
+            Picker("", selection: $rememberTarget) {
+                if let host = domainForURL {
+                    Text(includeSubdomains ? "*.\(rootDomainForURL ?? host)" : host).tag(RememberTarget.domain)
+                } else {
+                    Text("This URL").tag(RememberTarget.domain)
+                }
+                if canRememberForApp, let name = sourceAppName {
+                    Text("Links from \(name)").tag(RememberTarget.sourceApp)
+                }
+            }
+            .pickerStyle(.segmented)
+            .controlSize(.small)
+
+            if rememberTarget == .domain {
+                Toggle(isOn: $includeSubdomains) {
+                    Text("Include all subdomains")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                .toggleStyle(.checkbox)
+                .controlSize(.mini)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Color.accentColor.opacity(0.08))
     }
 }
 

--- a/BrowserPicker/Views/RouterPopup/RouterPopupView.swift
+++ b/BrowserPicker/Views/RouterPopup/RouterPopupView.swift
@@ -7,6 +7,8 @@ struct RouterPopupView: View {
     let url: URL
     let browsers: [Browser]
     let profiles: [String: [BrowserProfile]]
+    let sourceAppBundleID: String?
+    let sourceAppName: String?
     @ObservedObject var keyboardState: PopupKeyboardState
     let onProfileSelected: (Browser, BrowserProfile?, Bool) -> Void
 


### PR DESCRIPTION
## Summary

Closes #3

Stacked on top of #10. Adds the ability to turn a one-off browser pick into a persistent rule, without slowing down the fast default click-to-open flow.

### UX approach

A new bookmark icon in the URL header toggles "Remember next choice" mode. **Default off**, so day-to-day clicks behave exactly as before — zero extra steps.

When the bookmark is toggled on, an inline strip appears in the same popup (no second sheet, no second screen) with a segmented control:

- **This domain** (e.g., `docs.google.com`) — with an optional "Include all subdomains" checkbox that saves the rule against the root domain
- **Links from <App>** (only shown when the source app is known and isn't BrowserPicker itself)

Then the next browser/profile pick launches the URL **and** persists the rule.

### Changes

- **Source app threaded into popup** — `FloatingPanelController.show` now takes the source `NSRunningApplication`, and `RouterPopupView` knows the source bundle ID + display name.
- **Bookmark toggle** in the URL header (next to the incognito toggle) — minimal, opt-in.
- **Inline `rememberStrip`** below the URL header when the toggle is on. Segmented picker for domain vs source app; subdomain checkbox under the domain option.
- **`launch(browser:profile:)`** helper centralizes the launch path so all flows (mouse click, keyboard 1–9, Enter) honor the remember toggle.
- **Conflict handling**: before appending the new rule, any existing rule with the same source app + pattern is removed. Repeated remembers update in place rather than stacking duplicates.

### Commits

1. Thread source app bundle ID and display name into the router popup
2. Add inline Remember toggle, save-as strip, and rule persistence with conflict handling

## Test plan

- [ ] Click a link with the bookmark off — confirm the popup shows and clicking a browser launches immediately as before (no rule created)
- [ ] Click a link, toggle the bookmark icon — confirm the inline strip appears with the domain pre-selected
- [ ] If the link came from an app like Slack — confirm "Links from Slack" segment appears
- [ ] If the link came from BrowserPicker itself or no source app — confirm only the domain segment appears
- [ ] Toggle "Include all subdomains" — confirm the segment label updates to *.example.com
- [ ] Pick a browser → URL opens AND a new rule shows up under Settings → Rules
- [ ] Toggle remember on, pick "Links from Slack", select Chrome Work — confirm the saved rule has empty pattern and source app = Slack
- [ ] Trigger remember twice for the same domain with different browsers — confirm only one rule exists in Settings (the second replaces the first)
- [ ] Open Settings → Rules and confirm the new rule's display matches the popup choice (incognito, profile, etc.)

Made with [Cursor](https://cursor.com)