### PR TITLE
Import/Export Config

### DIFF
--- a/BrowserPicker/AppDelegate.swift
+++ b/BrowserPicker/AppDelegate.swift
@@ -76,6 +76,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func application(_ application: NSApplication, open urls: [URL]) {
         guard let rawURL = urls.first else { return }
+
+        // Handle .browserpicker config files opened from Finder by routing
+        // them to the import flow rather than the URL launcher.
+        if rawURL.isFileURL && rawURL.pathExtension.lowercased() == "browserpicker" {
+            handleConfigFileOpen(rawURL)
+            return
+        }
+
         // Capture the source app synchronously, before any other work — the
         // frontmost app at this moment is almost always the app the user
         // clicked the link in.
@@ -114,6 +122,66 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         panelController.show(url: url, browsers: browsers, profiles: profiles, sourceApp: sourceApp)
+    }
+
+    private func handleConfigFileOpen(_ fileURL: URL) {
+        do {
+            let data = try Data(contentsOf: fileURL)
+            let package = try ConfigService.decode(data)
+            presentImportPrompt(for: package, sourceFilename: fileURL.lastPathComponent)
+        } catch {
+            let alert = NSAlert()
+            alert.messageText = "Could not import configuration"
+            alert.informativeText = "The file \(fileURL.lastPathComponent) could not be read: \(error.localizedDescription)"
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: "OK")
+            NSApp.setActivationPolicy(.regular)
+            NSApp.activate(ignoringOtherApps: true)
+            alert.runModal()
+        }
+    }
+
+    private func presentImportPrompt(for package: ConfigPackage, sourceFilename: String) {
+        NSApp.setActivationPolicy(.regular)
+        NSApp.activate(ignoringOtherApps: true)
+
+        let alert = NSAlert()
+        alert.messageText = "Import \(sourceFilename)?"
+        var details = "\(package.rules.count) rule(s), \(package.rewrites.count) rewrite(s)"
+        if let history = package.history, !history.isEmpty {
+            details += ", \(history.count) history entries (not applied)"
+        }
+        details += "\nExported from BrowserPicker v\(package.appVersion)."
+        details += "\n\nReplace All wipes your existing rules and rewrites. Merge keeps yours and skips duplicates."
+        alert.informativeText = details
+        alert.addButton(withTitle: "Replace All")
+        alert.addButton(withTitle: "Merge")
+        alert.addButton(withTitle: "Cancel")
+
+        let response = alert.runModal()
+        switch response {
+        case .alertFirstButtonReturn:
+            let summary = ConfigService.apply(package, strategy: .replace)
+            showImportSummary(summary, strategy: .replace)
+        case .alertSecondButtonReturn:
+            let summary = ConfigService.apply(package, strategy: .merge)
+            showImportSummary(summary, strategy: .merge)
+        default:
+            break
+        }
+    }
+
+    private func showImportSummary(_ summary: ImportSummary, strategy: ImportStrategy) {
+        let alert = NSAlert()
+        alert.messageText = "Import complete"
+        switch strategy {
+        case .replace:
+            alert.informativeText = "Replaced existing configuration.\nRules: \(summary.rulesAdded), Rewrites: \(summary.rewritesAdded)"
+        case .merge:
+            alert.informativeText = "Merged into existing configuration.\nRules added: \(summary.rulesAdded) (skipped \(summary.rulesSkipped))\nRewrites added: \(summary.rewritesAdded) (skipped \(summary.rewritesSkipped))"
+        }
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
     }
 
     @objc private func handleOpenSettings() {

--- a/BrowserPicker/Info.plist
+++ b/BrowserPicker/Info.plist
@@ -44,6 +44,43 @@
 				<string>public.xhtml</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>BrowserPicker Configuration</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.orpic.browserpicker.config</string>
+			</array>
+		</dict>
+	</array>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>com.orpic.browserpicker.config</string>
+			<key>UTTypeDescription</key>
+			<string>BrowserPicker Configuration</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.json</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>browserpicker</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>application/json</string>
+				</array>
+			</dict>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/BrowserPicker/Services/ConfigService.swift
+++ b/BrowserPicker/Services/ConfigService.swift
@@ -1,0 +1,127 @@
+// BrowserPicker — Copyright (c) 2026 Shobhit. All rights reserved.
+// Licensed under a proprietary license. See LICENSE file for details.
+
+import Foundation
+
+struct ConfigPackage: Codable {
+    static let currentSchemaVersion: Int = 1
+
+    var schemaVersion: Int
+    var exportedAt: Date
+    var appVersion: String
+    var rules: [DomainRule]
+    var rewrites: [RewriteRule]
+    var history: [HistoryEntry]?
+
+    init(rules: [DomainRule], rewrites: [RewriteRule], history: [HistoryEntry]? = nil) {
+        self.schemaVersion = Self.currentSchemaVersion
+        self.exportedAt = Date()
+        self.appVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
+        self.rules = rules
+        self.rewrites = rewrites
+        self.history = history
+    }
+}
+
+enum ImportStrategy {
+    /// Wipes existing rules and rewrites, then applies the imported config.
+    case replace
+    /// Appends imported rules and rewrites to existing ones, skipping
+    /// any duplicates already present.
+    case merge
+}
+
+struct ImportSummary {
+    var rulesAdded: Int = 0
+    var rulesSkipped: Int = 0
+    var rewritesAdded: Int = 0
+    var rewritesSkipped: Int = 0
+    var historyImported: Int = 0
+}
+
+struct ConfigService {
+    /// Builds a `ConfigPackage` from current persisted state.
+    static func currentPackage(includeHistory: Bool) -> ConfigPackage {
+        let rules = RuleEngine.loadRules()
+        let rewrites = URLRewriter.loadRules()
+        let history = includeHistory ? HistoryService.loadHistory() : nil
+        return ConfigPackage(rules: rules, rewrites: rewrites, history: history)
+    }
+
+    /// Encodes a package as pretty-printed JSON suitable for writing to disk.
+    static func encode(_ package: ConfigPackage) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(package)
+    }
+
+    /// Decodes a `ConfigPackage` from JSON data; supports the ISO8601 dates
+    /// produced by `encode(_:)`.
+    static func decode(_ data: Data) throws -> ConfigPackage {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(ConfigPackage.self, from: data)
+    }
+
+    /// Applies an imported package using the chosen strategy and returns a
+    /// summary the caller can show to the user.
+    @discardableResult
+    static func apply(_ package: ConfigPackage, strategy: ImportStrategy) -> ImportSummary {
+        var summary = ImportSummary()
+
+        switch strategy {
+        case .replace:
+            RuleEngine.saveRules(package.rules)
+            URLRewriter.saveRules(package.rewrites)
+            summary.rulesAdded = package.rules.count
+            summary.rewritesAdded = package.rewrites.count
+
+        case .merge:
+            var existingRules = RuleEngine.loadRules()
+            for incoming in package.rules {
+                if existingRules.contains(where: { isDuplicate(existing: $0, incoming: incoming) }) {
+                    summary.rulesSkipped += 1
+                } else {
+                    var copy = incoming
+                    copy.id = UUID()
+                    existingRules.append(copy)
+                    summary.rulesAdded += 1
+                }
+            }
+            RuleEngine.saveRules(existingRules)
+
+            var existingRewrites = URLRewriter.loadRules()
+            for incoming in package.rewrites {
+                if existingRewrites.contains(where: { isDuplicate(existing: $0, incoming: incoming) }) {
+                    summary.rewritesSkipped += 1
+                } else {
+                    var copy = incoming
+                    copy.id = UUID()
+                    existingRewrites.append(copy)
+                    summary.rewritesAdded += 1
+                }
+            }
+            URLRewriter.saveRules(existingRewrites)
+        }
+
+        // History is informational; we never overwrite history during
+        // import. If the package contains history entries, we record the
+        // count for display but do not persist them.
+        summary.historyImported = package.history?.count ?? 0
+
+        return summary
+    }
+
+    private static func isDuplicate(existing: DomainRule, incoming: DomainRule) -> Bool {
+        existing.pattern.lowercased() == incoming.pattern.lowercased() &&
+        existing.matchType == incoming.matchType &&
+        existing.browserBundleID == incoming.browserBundleID &&
+        (existing.profileDirectory ?? "") == (incoming.profileDirectory ?? "") &&
+        (existing.sourceAppBundleID ?? "") == (incoming.sourceAppBundleID ?? "")
+    }
+
+    private static func isDuplicate(existing: RewriteRule, incoming: RewriteRule) -> Bool {
+        existing.pattern == incoming.pattern && existing.replacement == incoming.replacement
+    }
+}

--- a/BrowserPicker/SettingsView.swift
+++ b/BrowserPicker/SettingsView.swift
@@ -3,6 +3,7 @@
 
 import SwiftUI
 import ServiceManagement
+import UniformTypeIdentifiers
 
 struct SettingsView: View {
     @State private var selectedTab = 0
@@ -32,18 +33,53 @@ struct SettingsView: View {
 private struct GeneralSettingsTab: View {
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
     @State private var isDefaultBrowser = false
+    @State private var includeHistoryInExport = false
+    @State private var pendingImport: ConfigPackage?
+    @State private var importErrorMessage: String?
+    @State private var importSummaryMessage: String?
 
     var body: some View {
-        VStack(spacing: 16) {
-            aboutSection
-            Divider()
-            settingsSection
-            Divider()
-            defaultBrowserSection
-            Spacer()
+        ScrollView {
+            VStack(spacing: 16) {
+                aboutSection
+                Divider()
+                settingsSection
+                Divider()
+                defaultBrowserSection
+                Divider()
+                backupSection
+            }
+            .padding(20)
         }
-        .padding(20)
         .onAppear { checkDefaultBrowser() }
+        .sheet(item: Binding(
+            get: { pendingImport.map { ImportSheetPayload(package: $0) } },
+            set: { pendingImport = $0?.package }
+        )) { payload in
+            ImportPreviewSheet(package: payload.package, onApply: { strategy in
+                let summary = ConfigService.apply(payload.package, strategy: strategy)
+                importSummaryMessage = format(summary: summary, strategy: strategy)
+                pendingImport = nil
+            }, onCancel: {
+                pendingImport = nil
+            })
+        }
+        .alert("Import failed", isPresented: Binding(
+            get: { importErrorMessage != nil },
+            set: { if !$0 { importErrorMessage = nil } }
+        )) {
+            Button("OK") { importErrorMessage = nil }
+        } message: {
+            Text(importErrorMessage ?? "")
+        }
+        .alert("Import complete", isPresented: Binding(
+            get: { importSummaryMessage != nil },
+            set: { if !$0 { importSummaryMessage = nil } }
+        )) {
+            Button("OK") { importSummaryMessage = nil }
+        } message: {
+            Text(importSummaryMessage ?? "")
+        }
     }
 
     private var aboutSection: some View {
@@ -106,6 +142,155 @@ private struct GeneralSettingsTab: View {
             let bundleID = Bundle(url: defaultBrowser)?.bundleIdentifier
             isDefaultBrowser = bundleID == Bundle.main.bundleIdentifier
         }
+    }
+
+    private var backupSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Backup & Sharing")
+                .font(.headline)
+
+            Text("Export your rules and rewrites to a single file you can back up or share with teammates. Imported rules can replace yours or be merged in.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Toggle(isOn: $includeHistoryInExport) {
+                Text("Include link history in export")
+                    .font(.caption)
+            }
+            .toggleStyle(.checkbox)
+            .controlSize(.small)
+
+            HStack {
+                Button("Export…") {
+                    runExport(includeHistory: includeHistoryInExport)
+                }
+                Button("Import…") {
+                    runImport()
+                }
+                Spacer()
+            }
+        }
+    }
+
+    private func runExport(includeHistory: Bool) {
+        let panel = NSSavePanel()
+        panel.title = "Export BrowserPicker Configuration"
+        panel.allowedContentTypes = [BrowserPickerConfigType.utType]
+        panel.nameFieldStringValue = defaultExportFilename()
+        panel.canCreateDirectories = true
+
+        guard panel.runModal() == .OK, let destination = panel.url else { return }
+
+        do {
+            let package = ConfigService.currentPackage(includeHistory: includeHistory)
+            let data = try ConfigService.encode(package)
+            try data.write(to: destination, options: .atomic)
+        } catch {
+            importErrorMessage = "Could not write file: \(error.localizedDescription)"
+        }
+    }
+
+    private func runImport() {
+        let panel = NSOpenPanel()
+        panel.title = "Import BrowserPicker Configuration"
+        panel.allowedContentTypes = [BrowserPickerConfigType.utType]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+
+        guard panel.runModal() == .OK, let source = panel.url else { return }
+
+        do {
+            let data = try Data(contentsOf: source)
+            let package = try ConfigService.decode(data)
+            pendingImport = package
+        } catch {
+            importErrorMessage = "Could not read file: \(error.localizedDescription)"
+        }
+    }
+
+    private func defaultExportFilename() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return "browserpicker-\(formatter.string(from: Date())).browserpicker"
+    }
+
+    private func format(summary: ImportSummary, strategy: ImportStrategy) -> String {
+        var lines: [String] = []
+        switch strategy {
+        case .replace:
+            lines.append("Replaced existing configuration.")
+            lines.append("Rules imported: \(summary.rulesAdded)")
+            lines.append("Rewrites imported: \(summary.rewritesAdded)")
+        case .merge:
+            lines.append("Merged into existing configuration.")
+            lines.append("Rules added: \(summary.rulesAdded) (skipped \(summary.rulesSkipped) duplicates)")
+            lines.append("Rewrites added: \(summary.rewritesAdded) (skipped \(summary.rewritesSkipped) duplicates)")
+        }
+        if summary.historyImported > 0 {
+            lines.append("History entries in package: \(summary.historyImported) (not applied)")
+        }
+        return lines.joined(separator: "\n")
+    }
+}
+
+enum BrowserPickerConfigType {
+    static let utType: UTType = UTType(exportedAs: "com.orpic.browserpicker.config", conformingTo: .json)
+}
+
+private struct ImportSheetPayload: Identifiable {
+    let id = UUID()
+    let package: ConfigPackage
+}
+
+private struct ImportPreviewSheet: View {
+    let package: ConfigPackage
+    let onApply: (ImportStrategy) -> Void
+    let onCancel: () -> Void
+
+    private static let dateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .medium
+        f.timeStyle = .short
+        return f
+    }()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Import Configuration")
+                .font(.headline)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Label("\(package.rules.count) rule(s)", systemImage: "list.bullet.rectangle")
+                Label("\(package.rewrites.count) rewrite(s)", systemImage: "arrow.triangle.swap")
+                if let history = package.history, !history.isEmpty {
+                    Label("\(history.count) history entries (will not be applied)", systemImage: "clock")
+                        .foregroundStyle(.secondary)
+                }
+                Label("Exported \(Self.dateFormatter.string(from: package.exportedAt)) from v\(package.appVersion)", systemImage: "info.circle")
+                    .foregroundStyle(.secondary)
+            }
+            .font(.caption)
+
+            Divider()
+
+            Text("Choose how to apply this configuration:")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            HStack {
+                Button("Cancel", action: onCancel)
+                    .keyboardShortcut(.cancelAction)
+                Spacer()
+                Button("Merge") { onApply(.merge) }
+                    .help("Add imported rules to your existing ones, skipping duplicates")
+                Button("Replace All") { onApply(.replace) }
+                    .help("Wipe existing rules and rewrites, then apply the imported configuration")
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(20)
+        .frame(width: 420)
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #5

Stacked on top of #11. Adds the ability to export your rules and rewrites to a single shareable file and import a config from someone else (or your other Mac).

### Use cases

- A PM creates a clean rule set, exports it, drops the file in Slack, and teammates double-click to import
- Backup your config before reinstalling
- Move your setup to a new Mac

### Changes

- **`ConfigPackage` model + `ConfigService`** — Versioned schema (currently v1) bundling rules, rewrites, optional history, app version, and timestamp. Service handles encode/decode (ISO8601 dates) and applies imports with either Replace All or Merge strategies.
- **Merge strategy** — Skips items whose key fields already exist (rules: pattern + match type + browser + profile + source app; rewrites: pattern + replacement). Generates fresh UUIDs for incoming items so they don't collide.
- **Replace strategy** — Wipes existing rules and rewrites, then writes the imported set verbatim.
- **History is informational on import** — The package can carry history entries for context, but they are never written over the user's local history. The import summary mentions if the package contained history.
- **"Backup & Sharing" section in Settings → General** — Export and Import buttons, with a checkbox to include history in exports. The import preview sheet shows rule/rewrite/history counts and lets the user pick Replace All or Merge.
- **`.browserpicker` UTI** — Custom exported type (`com.orpic.browserpicker.config` conforming to `public.json`) with `.browserpicker` extension. Info.plist registers BrowserPicker as Owner of that document type.
- **Finder integration** — `AppDelegate.application(_:open:)` detects `.browserpicker` file URLs (so HTTP routing is unaffected) and routes them through a native NSAlert offering Replace All / Merge / Cancel, followed by a summary alert.

### Commits

1. Add `ConfigPackage` model and `ConfigService`
2. Add Backup & Sharing section in Settings (export + import)
3. Register `.browserpicker` UTI and handle Finder opens

## Test plan

- [ ] Create a couple of rules and rewrites
- [ ] Open Settings → General → Backup & Sharing → Export — confirm save panel defaults to `browserpicker-YYYY-MM-DD.browserpicker`
- [ ] Save the file; open it in any text editor — confirm valid pretty-printed JSON with schemaVersion, exportedAt, appVersion, rules, rewrites
- [ ] Toggle "Include link history in export"; export again — confirm `history` array is present in the JSON
- [ ] Settings → Import — pick the exported file
- [ ] Preview sheet shows correct counts; pick Merge — confirm summary alert says "skipped N duplicates" since you're importing your own config
- [ ] Delete a rule; import again with Merge — confirm only that one rule is added back
- [ ] Import again with Replace All — confirm everything is replaced
- [ ] Quit the app, double-click a `.browserpicker` file in Finder — confirm BrowserPicker launches and shows the Replace/Merge/Cancel alert
- [ ] Click an http link from elsewhere — confirm normal popup still works (file URL detection didn't break URL routing)

Made with [Cursor](https://cursor.com)