### PR TITLE
History Enhancements: Re-open + CSV Export

### DIFF
--- a/BrowserPicker/AppDelegate.swift
+++ b/BrowserPicker/AppDelegate.swift
@@ -18,6 +18,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             object: nil
         )
 
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleRouteURL(_:)),
+            name: .routeURL,
+            object: nil
+        )
+
         panelController.onProfileSelected = { [weak self] browser, profile, incognito in
             guard let self, let url = self.pendingURL else { return }
             URLLauncher.launch(url: url, browser: browser, profile: profile, incognito: incognito)
@@ -122,6 +129,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         panelController.show(url: url, browsers: browsers, profiles: profiles, sourceApp: sourceApp)
+    }
+
+    @objc private func handleRouteURL(_ notification: Notification) {
+        guard let url = notification.userInfo?["url"] as? URL else { return }
+        // The user explicitly requested the picker (e.g. from the History tab).
+        // Skip rule matching so they always get to choose.
+        showPopup(for: url, sourceApp: nil)
     }
 
     private func handleConfigFileOpen(_ fileURL: URL) {

--- a/BrowserPicker/MenuBarView.swift
+++ b/BrowserPicker/MenuBarView.swift
@@ -28,4 +28,8 @@ struct MenuBarView: View {
 
 extension Notification.Name {
     static let openSettings = Notification.Name("BrowserPicker.openSettings")
+    /// Posted with userInfo `["url": URL]` when the user wants the picker
+    /// popup for a URL that didn't come through the system default-browser
+    /// hand-off (e.g., from the History tab's "Open in..." action).
+    static let routeURL = Notification.Name("BrowserPicker.routeURL")
 }

--- a/BrowserPicker/SettingsView.swift
+++ b/BrowserPicker/SettingsView.swift
@@ -953,6 +953,7 @@ private struct AddRewriteRuleSheet: View {
 private struct HistorySettingsTab: View {
     @State private var entries: [HistoryEntry] = []
     @State private var searchText = ""
+    @State private var exportError: String?
 
     private var filteredEntries: [HistoryEntry] {
         if searchText.isEmpty { return entries }
@@ -980,6 +981,9 @@ private struct HistorySettingsTab: View {
                 Text("\(entries.count) entries")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                Button("Export…") { exportCSV() }
+                    .controlSize(.small)
+                    .disabled(entries.isEmpty)
                 Button("Clear") {
                     HistoryService.clearHistory()
                     entries = []
@@ -1003,34 +1007,143 @@ private struct HistorySettingsTab: View {
                 Spacer()
             } else {
                 List(filteredEntries) { entry in
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(entry.url)
-                            .font(.system(.caption, design: .monospaced))
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                        HStack(spacing: 4) {
-                            Text(entry.browserName)
-                                .font(.caption2)
-                                .foregroundStyle(.secondary)
-                            if let profile = entry.profileName {
-                                Text("→ \(profile)")
-                                    .font(.caption2)
-                                    .foregroundStyle(.secondary)
-                            }
-                            if entry.incognito {
-                                Image(systemName: "eye.slash")
-                                    .font(.caption2)
-                                    .foregroundStyle(.secondary)
-                            }
-                            Spacer()
-                            Text(Self.dateFormatter.string(from: entry.timestamp))
-                                .font(.caption2)
-                                .foregroundStyle(.tertiary)
-                        }
-                    }
+                    HistoryRow(entry: entry, onReopen: { reopen(entry) }, onOpenIn: { openInPicker(entry) })
                 }
             }
         }
         .onAppear { entries = HistoryService.loadHistory() }
+        .alert("Export failed", isPresented: Binding(
+            get: { exportError != nil },
+            set: { if !$0 { exportError = nil } }
+        )) {
+            Button("OK") { exportError = nil }
+        } message: {
+            Text(exportError ?? "")
+        }
+    }
+
+    private func reopen(_ entry: HistoryEntry) {
+        guard let url = URL(string: entry.url) else { return }
+        let browsers = BrowserDetector.detectInstalledBrowsers()
+        guard let browser = browsers.first(where: { $0.bundleID == entry.browserBundleID }) else {
+            // Browser is no longer installed — fall back to the picker.
+            openInPicker(entry)
+            return
+        }
+        let profile: BrowserProfile? = {
+            guard let profileName = entry.profileName else { return nil }
+            return ProfileDetector.detectProfiles(for: browser).first { $0.name == profileName }
+        }()
+        URLLauncher.launch(url: url, browser: browser, profile: profile, incognito: entry.incognito)
+        HistoryService.log(url: url, browser: browser, profile: profile, incognito: entry.incognito)
+        entries = HistoryService.loadHistory()
+    }
+
+    private func openInPicker(_ entry: HistoryEntry) {
+        guard let url = URL(string: entry.url) else { return }
+        NotificationCenter.default.post(name: .routeURL, object: nil, userInfo: ["url": url])
+    }
+
+    private func exportCSV() {
+        let panel = NSSavePanel()
+        panel.title = "Export Link History"
+        panel.allowedContentTypes = [.commaSeparatedText]
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        panel.nameFieldStringValue = "browserpicker-history-\(formatter.string(from: Date())).csv"
+        panel.canCreateDirectories = true
+
+        guard panel.runModal() == .OK, let destination = panel.url else { return }
+
+        do {
+            let csv = HistoryCSV.build(from: entries)
+            try csv.write(to: destination, atomically: true, encoding: .utf8)
+        } catch {
+            exportError = "Could not write file: \(error.localizedDescription)"
+        }
+    }
+}
+
+private struct HistoryRow: View {
+    let entry: HistoryEntry
+    let onReopen: () -> Void
+    let onOpenIn: () -> Void
+
+    private static let dateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .short
+        f.timeStyle = .short
+        return f
+    }()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(entry.url)
+                .font(.system(.caption, design: .monospaced))
+                .lineLimit(1)
+                .truncationMode(.middle)
+            HStack(spacing: 4) {
+                Text(entry.browserName)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                if let profile = entry.profileName {
+                    Text("→ \(profile)")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                if entry.incognito {
+                    Image(systemName: "eye.slash")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Text(Self.dateFormatter.string(from: entry.timestamp))
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .contentShape(Rectangle())
+        .contextMenu {
+            Button(action: onReopen) {
+                Label("Re-open in \(entry.browserName)", systemImage: "arrow.clockwise")
+            }
+            Button(action: onOpenIn) {
+                Label("Open in…", systemImage: "questionmark.app")
+            }
+            Divider()
+            Button(action: copyURL) {
+                Label("Copy URL", systemImage: "doc.on.doc")
+            }
+        }
+    }
+
+    private func copyURL() {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(entry.url, forType: .string)
+    }
+}
+
+enum HistoryCSV {
+    static func build(from entries: [HistoryEntry]) -> String {
+        let header = "timestamp,url,browser,profile,incognito"
+        let isoFormatter = ISO8601DateFormatter()
+        let rows = entries.map { entry -> String in
+            let fields = [
+                isoFormatter.string(from: entry.timestamp),
+                entry.url,
+                entry.browserName,
+                entry.profileName ?? "",
+                entry.incognito ? "true" : "false",
+            ]
+            return fields.map(escape).joined(separator: ",")
+        }
+        return ([header] + rows).joined(separator: "\n") + "\n"
+    }
+
+    private static func escape(_ field: String) -> String {
+        let needsQuoting = field.contains(",") || field.contains("\"") || field.contains("\n") || field.contains("\r")
+        if !needsQuoting { return field }
+        let escaped = field.replacingOccurrences(of: "\"", with: "\"\"")
+        return "\"\(escaped)\""
     }
 }


### PR DESCRIPTION
## Summary

Closes #6

Stacked on top of #12. Turns the History tab from a read-only log into something useful — re-launch links with one click, send links back through the picker, or export the whole list to CSV.

### Changes

- **`.routeURL` notification** — Lightweight contract: post with `userInfo: ["url": URL]` to ask the AppDelegate to show the picker for a given URL. AppDelegate observes it and runs `showPopup(for:sourceApp:)` with no source app context (this is an explicit user action, not a hand-off). Rule matching is intentionally skipped so the user always gets the picker.
- **History row context menu** (right-click on any entry):
  - **Re-open in <browser>** — Relaunches in the same browser + profile using `BrowserDetector` + `ProfileDetector` (profile lookup by name). If the original browser is no longer installed, falls back to the picker.
  - **Open in…** — Posts `.routeURL` so the user can pick a different browser/profile via the popup.
  - **Copy URL** — Quick clipboard copy.
- **CSV export** — New "Export…" button in the History header. Uses `NSSavePanel` with `.commaSeparatedText`, writes a UTF-8 CSV with columns `timestamp,url,browser,profile,incognito`. RFC 4180 quoting: fields with commas, quotes, or newlines are wrapped in double quotes and internal quotes are doubled.
- **`HistoryCSV` enum namespace** — Build and escape logic lives in a small standalone enum so it's easy to test or reuse later.

### Commits

1. Add re-open, open-in-picker, and CSV export to History (single commit since the changes are tightly coupled)

## Test plan

- [ ] Click a few links to populate history
- [ ] Open Settings → History → right-click any entry — confirm context menu shows Re-open / Open in… / Copy URL
- [ ] Pick "Re-open" — confirm the URL launches in the same browser+profile (and a new history entry is logged)
- [ ] Pick "Open in…" — confirm the floating picker appears with the URL
- [ ] Re-open an entry whose original browser has been uninstalled — confirm graceful fallback to the picker
- [ ] Click Export… — confirm save panel defaults to `browserpicker-history-YYYY-MM-DD.csv`
- [ ] Open the CSV in Numbers/Excel — confirm columns parse correctly and rows with commas in the URL stay intact
- [ ] Confirm "Open in…" works while Settings has focus (no source app should be associated with the popup)

Made with [Cursor](https://cursor.com)