### PR TITLE
Stats Dashboard

### DIFF
--- a/BrowserPicker/AppDelegate.swift
+++ b/BrowserPicker/AppDelegate.swift
@@ -111,7 +111,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 }
                 print("[BrowserPicker] Rule matched: \(match.rule.pattern) → \(browser.name)")
                 URLLauncher.launch(url: url, browser: browser, profile: profile, incognito: match.incognito)
-                HistoryService.log(url: url, browser: browser, profile: profile, incognito: match.incognito)
+                HistoryService.log(url: url, browser: browser, profile: profile, incognito: match.incognito, viaRule: true)
                 return
             }
         }

--- a/BrowserPicker/Models/HistoryEntry.swift
+++ b/BrowserPicker/Models/HistoryEntry.swift
@@ -11,8 +11,20 @@ struct HistoryEntry: Codable, Identifiable {
     var profileName: String?
     var incognito: Bool
     var timestamp: Date
+    /// True if this open was decided automatically by a matching rule.
+    /// False if the user picked the browser/profile from the popup (or
+    /// re-opened the link from history). Optional for backward compatibility
+    /// with history.json files written before this field existed.
+    var viaRule: Bool?
 
-    init(url: String, browserName: String, browserBundleID: String, profileName: String? = nil, incognito: Bool = false) {
+    init(
+        url: String,
+        browserName: String,
+        browserBundleID: String,
+        profileName: String? = nil,
+        incognito: Bool = false,
+        viaRule: Bool = false
+    ) {
         self.id = UUID()
         self.url = url
         self.browserName = browserName
@@ -20,5 +32,6 @@ struct HistoryEntry: Codable, Identifiable {
         self.profileName = profileName
         self.incognito = incognito
         self.timestamp = Date()
+        self.viaRule = viaRule
     }
 }

--- a/BrowserPicker/Services/HistoryService.swift
+++ b/BrowserPicker/Services/HistoryService.swift
@@ -7,7 +7,7 @@ struct HistoryService {
     private static let historyFile = "history.json"
     private static let maxEntries = 500
 
-    static func log(url: URL, browser: Browser, profile: BrowserProfile?, incognito: Bool) {
+    static func log(url: URL, browser: Browser, profile: BrowserProfile?, incognito: Bool, viaRule: Bool = false) {
         var entries = loadHistory()
 
         let entry = HistoryEntry(
@@ -15,7 +15,8 @@ struct HistoryService {
             browserName: browser.name,
             browserBundleID: browser.bundleID,
             profileName: profile?.name,
-            incognito: incognito
+            incognito: incognito,
+            viaRule: viaRule
         )
 
         entries.insert(entry, at: 0)

--- a/BrowserPicker/SettingsView.swift
+++ b/BrowserPicker/SettingsView.swift
@@ -22,11 +22,15 @@ struct SettingsView: View {
                 .tabItem { Label("Rewrite", systemImage: "arrow.triangle.swap") }
                 .tag(2)
 
+            StatsSettingsTab()
+                .tabItem { Label("Stats", systemImage: "chart.bar") }
+                .tag(3)
+
             HistorySettingsTab()
                 .tabItem { Label("History", systemImage: "clock") }
-                .tag(3)
+                .tag(4)
         }
-        .frame(width: 520, height: 420)
+        .frame(width: 520, height: 460)
     }
 }
 
@@ -947,6 +951,186 @@ private struct AddRewriteRuleSheet: View {
         }
         .padding(20)
         .frame(width: 420)
+    }
+}
+
+private struct StatsSettingsTab: View {
+    @State private var entries: [HistoryEntry] = []
+
+    private var stats: HistoryStats { HistoryStats(entries: entries) }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Stats")
+                    .font(.headline)
+
+                if entries.isEmpty {
+                    VStack(spacing: 8) {
+                        Image(systemName: "chart.bar")
+                            .imageScale(.large)
+                            .font(.title)
+                            .foregroundStyle(.tertiary)
+                        Text("No data yet")
+                            .foregroundStyle(.secondary)
+                        Text("Stats are computed from your link history.\nOpen a few links to see them here.")
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                            .multilineTextAlignment(.center)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.top, 40)
+                } else {
+                    countersRow
+                    autoRoutedRow
+                    HStack(alignment: .top, spacing: 12) {
+                        topListCard(title: "Top browsers", items: stats.topBrowsers)
+                        topListCard(title: "Top domains", items: stats.topDomains)
+                    }
+                }
+            }
+            .padding(20)
+        }
+        .onAppear { entries = HistoryService.loadHistory() }
+    }
+
+    private var countersRow: some View {
+        HStack(spacing: 12) {
+            counterCard(title: "Total", value: "\(stats.totalCount)")
+            counterCard(title: "This week", value: "\(stats.thisWeekCount)")
+            counterCard(title: "Today", value: "\(stats.todayCount)")
+        }
+    }
+
+    private func counterCard(title: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.title.bold())
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.secondary.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    @ViewBuilder
+    private var autoRoutedRow: some View {
+        let total = max(stats.viaRuleCount + stats.manualCount, 1)
+        let pct = Int((Double(stats.viaRuleCount) / Double(total)) * 100)
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Label("Auto-routed by rules", systemImage: "wand.and.rays")
+                    .font(.caption.bold())
+                Spacer()
+                Text("\(pct)% (\(stats.viaRuleCount) of \(total))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Color.secondary.opacity(0.15))
+                        .frame(height: 8)
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Color.accentColor)
+                        .frame(width: geo.size.width * CGFloat(stats.viaRuleCount) / CGFloat(total), height: 8)
+                }
+            }
+            .frame(height: 8)
+        }
+        .padding(12)
+        .background(Color.secondary.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    private func topListCard(title: String, items: [HistoryStats.RankedItem]) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.caption.bold())
+                .foregroundStyle(.secondary)
+            if items.isEmpty {
+                Text("No data")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            } else {
+                ForEach(Array(items.enumerated()), id: \.offset) { index, item in
+                    HStack(spacing: 6) {
+                        Text("#\(index + 1)")
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(.tertiary)
+                            .frame(width: 24, alignment: .leading)
+                        Text(item.label)
+                            .font(.caption)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Spacer()
+                        Text("\(item.count)")
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(Color.secondary.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+struct HistoryStats {
+    struct RankedItem {
+        let label: String
+        let count: Int
+    }
+
+    let totalCount: Int
+    let todayCount: Int
+    let thisWeekCount: Int
+    let viaRuleCount: Int
+    let manualCount: Int
+    let topBrowsers: [RankedItem]
+    let topDomains: [RankedItem]
+
+    init(entries: [HistoryEntry], topN: Int = 5, now: Date = Date(), calendar: Calendar = .current) {
+        totalCount = entries.count
+
+        let startOfToday = calendar.startOfDay(for: now)
+        let startOfWeek = calendar.dateInterval(of: .weekOfYear, for: now)?.start ?? startOfToday
+        todayCount = entries.filter { $0.timestamp >= startOfToday }.count
+        thisWeekCount = entries.filter { $0.timestamp >= startOfWeek }.count
+
+        viaRuleCount = entries.filter { $0.viaRule == true }.count
+        manualCount = totalCount - viaRuleCount
+
+        topBrowsers = Self.rank(entries: entries, key: { entry in
+            if let profile = entry.profileName {
+                return "\(entry.browserName) / \(profile)"
+            }
+            return entry.browserName
+        }, top: topN)
+
+        topDomains = Self.rank(entries: entries, key: { entry in
+            URL(string: entry.url)?.host ?? entry.url
+        }, top: topN)
+    }
+
+    private static func rank(entries: [HistoryEntry], key: (HistoryEntry) -> String, top: Int) -> [RankedItem] {
+        var counts: [String: Int] = [:]
+        for entry in entries {
+            let k = key(entry)
+            counts[k, default: 0] += 1
+        }
+        return counts.map { RankedItem(label: $0.key, count: $0.value) }
+            .sorted { lhs, rhs in
+                if lhs.count != rhs.count { return lhs.count > rhs.count }
+                return lhs.label.localizedCaseInsensitiveCompare(rhs.label) == .orderedAscending
+            }
+            .prefix(top)
+            .map { $0 }
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #7

Stacked on top of #13. Adds a new Stats tab in Settings with light analytics computed entirely from existing history.

### Changes

- **`HistoryEntry.viaRule`** — Optional Bool field tracking whether the open was decided by a rule or chosen manually. Optional for backward compatibility with old history.json files. Set to `true` only on the rule-match path in AppDelegate; popup picks and history re-opens default to `false`.
- **`HistoryStats`** — Pure value type that computes all metrics from a `[HistoryEntry]`. Takes `now` and `calendar` injectable for deterministic testing. Builds:
  - Total / This week / Today counts
  - Auto-routed (viaRule == true) vs Manual counts and percentage
  - Top N browsers ranked by occurrence (browser + profile when present)
  - Top N domains ranked by URL host
- **Stats tab** in Settings (between Rewrite and History):
  - Three counter cards (Total / This week / Today) at the top
  - Auto-routed progress bar with percentage and "X of Y" caption
  - Two ranked list cards side-by-side: Top browsers and Top domains
  - Empty state when there's no history yet
- Settings window grew from 420 to 460 height to accommodate the new tab content.

### Why no charts?

Plan was explicit: text-based ranked lists are sufficient for v1. No external charting dependency, fast render, easy to scan. We can add SwiftUI Charts later if asked.

### Commits

1. Track whether history entries came from a rule (viaRule plumbing)
2. Add Stats tab in Settings (UI + HistoryStats compute)

## Test plan

- [ ] Trigger a few link opens — both via rule (matching domain) and via manual popup pick
- [ ] Open Settings → Stats — confirm Total / This week / Today numbers reflect actual history counts
- [ ] Confirm Auto-routed bar shows the expected percentage (manual picks count toward Manual; rule matches count toward Auto-routed)
- [ ] Confirm Top browsers shows browser name + profile (when present) ranked by count
- [ ] Confirm Top domains lists hosts (e.g., docs.google.com) ranked by count
- [ ] Open the same domain via several different browsers — confirm rankings update on next visit to the tab
- [ ] Clear history from the History tab; come back to Stats — confirm empty state shows

Made with [Cursor](https://cursor.com)